### PR TITLE
Added usernames blacklist

### DIFF
--- a/app/models/concerns/blacklist.rb
+++ b/app/models/concerns/blacklist.rb
@@ -1,0 +1,5 @@
+module Blacklist
+  def blacklist
+    @_blacklist ||= File.read(Rails.root.join 'lib', 'blacklist.txt').split
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,9 @@ class User < ApplicationRecord
   validates :username, presence: true, uniqueness: true
   validates :email, presence: true, uniqueness: true
 
+  extend Blacklist
+  validates :username, exclusion: { in: blacklist, message: "The username you choose is invalid, please try again." }
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/lib/blacklist.txt
+++ b/lib/blacklist.txt
@@ -1,0 +1,3 @@
+admin
+account_settings
+user_update


### PR DESCRIPTION
Added username blacklist feature that prevents a user from creating or updating a username with prohibited names, this is made to prevent conflicts with the routing set in `routes.rb`
- New blacklist textfile in the lib
- New model concern
- New validation for the user model